### PR TITLE
Up french translation

### DIFF
--- a/README.French.md
+++ b/README.French.md
@@ -83,7 +83,7 @@ Avantages :
 - 3ème niveau : Peut utiliser « Choc psionique » une fois par jour au niveau 1, puis une fois supplémentaire tous les 4 niveaux.  
 - 3ème niveau : Peut utiliser « Champ de force » une fois par jour au niveau 1, puis une fois supplémentaire tous les 4 niveaux.
 
-CHOC PSIONIQUE : Pendant un round, cette capacité permet à l'Esprit Guerrier d'effectuer une attaque spéciale et des dégâts supplémentaires contre n'importe quel type d'ennemi en appliquant un modificateur lié à l'intelligence.  
+CHOC PSIONIQUE : Pendant 10 secondes, cette capacité permet à l'Esprit Guerrier d'effectuer une attaque spéciale et des dégâts supplémentaires contre n'importe quel type d'ennemi en appliquant un modificateur lié à l'intelligence.  
 <details>
   <summary>Détails des dégâts</summary>
   
@@ -133,7 +133,11 @@ ATTRACTION CINÉTIQUE : L'Esprit Guerrier est capable de déplacer une créature
 
 - 10ème niveau : Gagne la capacité passive « Forteresse mentale ».
 
-FORTERESSE MENTALE : L'Esprit Guerrier devient immunisé contre toutes les attaques psioniques.
+FORTERESSE MENTALE : L'Esprit Guerrier devient immunisé contre toutes les attaques psioniques, la peur et les charmes.
+
+- 15ème niveau : Peut utiliser « Muraille » une fois par jour.
+
+MURAILLE : Cette capacité confère aux alliés se trouvant dans un rayon de 4,5 m autour de l'Esprit Guerrier une résistance aux dégâts de 10 % pendant un tour. Cet avantage n'est effectif qu'à proximité de l'Esprit Guerrier, qui lui-même ne bénéficie pas de ce bonus supplémentaire.
 
 - 18ème niveau : Peut utiliser « Maîtrise cinétique » une fois par jour
 
@@ -260,6 +264,30 @@ Avantages :
 Inconvénients :
 - Ne peut pas utiliser la capacité Repousser les morts-vivants.
 - Ne peut pas investir plus d'un point de compétence dans les armes à deux mains et les armes à distance.
+
+### Ravageur
+
+Les Ravageurs sont des guerriers maléfiques qui se délectent de la mort et de la destruction de toute forme de vie. Utilisant les arts nécrotiques pour le combat, ils drainent l'essence vitale de leurs adversaires, et certains d'entre eux peuvent même dévorer l'âme de leurs victimes.
+
+Avantages :
+- Peut Repousser les morts-vivants comme un paladin.
+- Peut utiliser la capacité « Siphon » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.
+
+SIPHON : Chaque coup réussi dans les 10 secondes qui suivent draine 1d4 points de vie à la cible et les transfère au Ravageur. Cette capacité ne permet de dépasser son maximum de points de vie.
+
+- 5ème Niveau : Gagne la capacité passive « Dévoreur d'âme ».
+
+DÉVOREUR D'ÂME : Quand le Ravageur terrasse un adversaire, il a 20 % de chances d'aspirer son essence vitale et de récupérer 10 points de vie.
+
+- 10ème Niveau : Peut utiliser la capacité « Champ de mort » une fois par jour, puis une fois supplémentaire tous les 5 niveaux.
+
+CHAMP DE MORT : Tous les ennemis situés dans un rayon de 4,5 mètres autour du Ravageur subissent 4 points de dégâts. Le Ravageur absorbe cette énergie vitale même au-delà de son maximum de points de vie. Ces points de vie supplémentaires disparaîtront après 1 tour. 
+
+Inconvénients :
+- Alignement mauvais uniquement.
+- Ne peut pas lancer « Détection du mal ».
+- Ne dispose pas de la capacité innée « Protection contre le mal ».
+- Ne peut utiliser « Imposition des mains ».
 
 ## Kits de Clerc
 

--- a/morpheus562-s-kitpack/languages/french/kit_descriptions.tra
+++ b/morpheus562-s-kitpack/languages/french/kit_descriptions.tra
@@ -23,7 +23,7 @@ Avantages :
 – 3ème niveau : Peut utiliser « Choc psionique » une fois par jour au niveau 1, puis une fois supplémentaire tous les 4 niveaux.
 – 3ème niveau : Peut utiliser « Champ de force » une fois par jour au niveau 1, puis une fois supplémentaire tous les 4 niveaux.
 
-CHOC PSIONIQUE : Pendant un round, cette capacité permet à l'Esprit Guerrier d'effectuer une attaque spéciale et des dégâts supplémentaires contre n'importe quel type d'ennemi en appliquant un modificateur lié à l'intelligence.
+CHOC PSIONIQUE : Pendant 10 secondes, cette capacité permet à l'Esprit Guerrier d'effectuer une attaque spéciale et des dégâts supplémentaires contre n'importe quel type d'ennemi en appliquant un modificateur lié à l'intelligence.
   13 en Intelligence : +1 point de dégâts
   14 en Intelligence : +2 points de dégâts
   15 en Intelligence : +3 points de dégâts
@@ -59,7 +59,11 @@ ATTRACTION CINÉTIQUE : L'Esprit Guerrier est capable de déplacer une créature
 
 – 10ème niveau : Gagne la capacité passive « Forteresse mentale ».
 
-FORTERESSE MENTALE : L'Esprit Guerrier devient immunisé contre toutes les attaques psioniques.
+FORTERESSE MENTALE : L'Esprit Guerrier devient immunisé contre toutes les attaques psioniques, la peur et les charmes.
+
+– 15ème niveau : Peut utiliser « Muraille » une fois par jour.
+
+MURAILLE : Cette capacité confère aux alliés se trouvant dans un rayon de 4,5 m autour de l'Esprit Guerrier une résistance aux dégâts de 10 % pendant un tour. Cet avantage n'est effectif qu'à proximité de l'Esprit Guerrier, qui lui-même ne bénéficie pas de ce bonus supplémentaire.
 
 – 18ème niveau : Peut utiliser « Maîtrise cinétique » une fois par jour
 
@@ -71,7 +75,7 @@ Inconvénients :
 
 @5507 = ~Choc psionique~
 @5508 = ~Choc psionique
-Pendant un round, cette capacité permet à l'Esprit Guerrier d'effectuer une attaque spéciale et des dégâts supplémentaires contre n'importe quel type d'ennemi en appliquant  un modificateur lié à l'intelligence.
+Pendant 10 secondes, cette capacité permet à l'Esprit Guerrier d'effectuer une attaque spéciale et des dégâts supplémentaires contre n'importe quel type d'ennemi en appliquant  un modificateur lié à l'intelligence.
   13 en Intelligence : +1 point de dégâts
   14 en Intelligence : +2 points de dégâts
   15 en Intelligence : +3 points de dégâts
@@ -318,7 +322,7 @@ FLAMME FLAMBOYANTE : Le Défenseur de la Flamme d'Argent améliore « Flamme Br
 
 Inconvénients :
 – Ne peut utiliser des armes à distance.
-– Ne peut utiliser « Imposition des mains »~
+– Ne peut utiliser « Imposition des mains ».~
 
 @5557 = ~chevalier du temple~
 @5558 = ~Chevalier du temple~
@@ -429,3 +433,42 @@ L'Archimage a acquis une compréhension approfondie de la magie et de ses mécan
 @5581 = ~La Toile~
 
 @5582 = ~Armure vulnérable~
+
+@5583 = ~ravageur~
+@5584 = ~Ravageur~
+@5585 = ~RAVAGEUR : Les Ravageurs sont des guerriers maléfiques qui se délectent de la mort et de la destruction de toute forme de vie. Utilisant les arts nécrotiques pour le combat, ils drainent l'essence vitale de leurs adversaires, et certains d'entre eux peuvent même dévorer l'âme de leurs victimes.
+
+Avantages :
+- Peut Repousser les morts-vivants comme un paladin.
+– Peut utiliser la capacité « Siphon » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.
+
+SIPHON : Chaque coup réussi dans les 10 secondes qui suivent draine 1d4 points de vie à la cible et les transfère au Ravageur. Cette capacité ne permet de dépasser son maximum de points de vie.
+
+– 5ème Niveau : Gagne la capacité passive « Dévoreur d'âme ».
+
+DÉVOREUR D'ÂME : Quand le Ravageur terrasse un adversaire, il a 20 % de chances d'aspirer son essence vitale et de récupérer 10 points de vie.
+
+– 10ème Niveau : Peut utiliser la capacité « Champ de mort » une fois par jour, puis une fois supplémentaire tous les 5 niveaux.
+
+CHAMP DE MORT : Tous les ennemis situés dans un rayon de 4,5 mètres autour du Ravageur subissent 4 points de dégâts. Le Ravageur absorbe cette énergie vitale même au-delà de son maximum de points de vie. Ces points de vie supplémentaires disparaîtront après 1 tour. 
+
+Inconvénients :
+– Alignement mauvais uniquement.
+- Ne peut pas lancer « Détection du mal ».
+- Ne dispose pas de la capacité innée « Protection contre le mal ».
+– Ne peut utiliser « Imposition des mains ».~
+
+@5586 = ~Siphon~
+@5587 = ~Siphon
+Chaque coup réussi dans les 10 secondes qui suivent draine 1d4 points de vie à la cible et les transfère au Ravageur. Cette capacité ne permet de dépasser son maximum de points de vie.~
+
+@5588 = ~Dévore l'âme de son adversaire~
+@5589 = ~Force vitale absorbée~
+
+@5590 = ~Champ de mort~
+@5591 = ~Champ de mort
+Tous les ennemis situés dans un rayon de 4,5 mètres autour du Ravageur subissent 4 points de dégâts. Le Ravageur absorbe cette énergie vitale même au-delà de son maximum de points de vie. Ces points de vie supplémentaires disparaîtront après 1 tour.~
+
+@5592 = ~Muraille~
+@5593 = ~MURAILLE
+Cette capacité confère aux alliés se trouvant dans un rayon de 4,5 m autour de l'Esprit Guerrier une résistance aux dégâts de 10 % pendant un tour. Cet avantage n'est effectif qu'à proximité de l'Esprit Guerrier, qui lui-même ne bénéficie pas de ce bonus supplémentaire.~

--- a/morpheus562-s-kitpack/languages/french/setup.tra
+++ b/morpheus562-s-kitpack/languages/french/setup.tra
@@ -41,6 +41,7 @@
 // Group 3 (Update 300-399)
 @300 = ~Installer le kit de paladin "Defenseur de la Flamme d'Argent"~ 
 @310 = ~Installer le kit de paladin "Chevalier du temple"~
+@320 = ~Installer le "Ravageur" un kit de paladin malefique~
 
 ///////////////////////////////////////////////////////////////////////////
 // Cleric                                                                //

--- a/morpheus562-s-kitpack/readme.french.html
+++ b/morpheus562-s-kitpack/readme.french.html
@@ -37,9 +37,6 @@
 <p><strong>Sur le Web</strong> : <a href="https://www.gibberlings3.net/forums/topic/36095-morpheus562s-kitpack/">Forum de discussion</a></p>
 <h2 id="introduction">Introduction</h2>
 <p>Ces kits ont des inspirations multiples afin d'inclure les sous-classes de la 5e edition ainsi que les classes de prestige de NWN2. Je voudrais souligner le travail phénoménal que Kaedrin a fait en introduisant de nombreuses classes de prestige dans NWN2 et j'emprunte à ses idées pour les intégrer dans le moteur Infinity Engine. Les kits mentionnés ci-dessous sont entièrement fonctionnels et de nouveaux kits sont actuellement en cours de développement.</p>
-<hr />
-<p><a href="https://github.com/Gibberlings3/Morpheus562-s-Kitpack/blob/main/README.French.md#kits-de-guerrier">Kits de Guerrier</a> / <a href="https://github.com/Gibberlings3/Morpheus562-s-Kitpack/blob/main/README.French.md#kits-de-r%C3%B4deur">Kits de Rôdeur</a> / <a href="https://github.com/Gibberlings3/Morpheus562-s-Kitpack/blob/main/README.French.md#kits-de-paladin">Kits de Paladin</a> / <a href="https://github.com/Gibberlings3/Morpheus562-s-Kitpack/blob/main/README.French.md#kits-densorceleur">Kits d'Ensorceleur</a> / <a href="https://github.com/Gibberlings3/Morpheus562-s-Kitpack/blob/main/README.French.md#kits-multiclasse">Kits Multiclasse</a> / <a href="https://github.com/Gibberlings3/Morpheus562-s-Kitpack/blob/main/README.French.md#classes-de-prestige">Classes de Prestige</a></p>
-<hr />
 <h2 id="kits-de-guerrier">Kits de Guerrier</h2>
 <h3 id="maître-de-bataille---kit-de-guerrier">Maître de Bataille - Kit de Guerrier</h3>
 <p>Expert dans les armes à deux mains, le Maître de Bataille est capable de faire des ravages sur les champs de bataille. D'une férocité et d'une résistance sans pareil, Ils déferlent sur leurs ennemis qui redoutent leur capacité à attaquer encore et encore sans faillir.</p>
@@ -65,25 +62,27 @@
 <p>Les Lanciers Dragons sont des guerriers qui consacrent leur vie à la maîtrise des armes d'hast (bâton, lance et hallebarde). Ces guerriers s'efforcent de maintenir leurs ennemis à distance tout en progressant le plus rapidement possible sur le champ de bataille.</p>
 <p>Avantages :</p>
 <ul>
-<li>Vitesse de déplacement augmenté de 2.</li>
-<li>La compétence avec les armes d'hast ( bâton, lance et hallebarde) donne au Lancier Dragon 20 % de chances de repousser un ennemi lors d'une attaque réussie et de lui infliger des dégâts perforants supplémentaires. Un jet de sauvegarde contre la mort à -2 permet à la cible d'éviter d'être projeté en arrière. Les dégâts supplémentaires augmentent avec les niveaux :</li>
+<li><p>Vitesse de déplacement augmenté de 2.</p>
+</li>
+<li><p>La compétence avec les armes d'hast ( bâton, lance et hallebarde) donne au Lancier Dragon 20 % de chances de repousser un ennemi lors d'une attaque réussie et de lui infliger des dégâts perforants supplémentaires. Un jet de sauvegarde contre la mort à -2 permet à la cible d'éviter d'être projeté en arrière. Les dégâts supplémentaires augmentent avec les niveaux :</p></li>
 </ul>
 <details>
   <summary>Détails des dégâts</summary>
-  
-```	
-  Niveau 1 à 2 : Inflige 1 point de dégâts perforants supplémentaires
-  Niveau 3 à 5 : Inflige 1d4 points de dégâts perforants supplémentaires
-  Niveau 6 à 8 : Inflige 1d6 points de dégâts perforants supplémentaires
-  Niveau 9 à 11 : Inflige 1d8 points de dégâts perforants supplémentaires
-  Niveau 12 à 14 : Inflige 2d4 points de dégâts perforants supplémentaires
-  Niveau 15 à 17 : Inflige 1d10 points de dégâts perforants supplémentaires
-  Niveau 18-20 : Inflige 2d6 points de dégâts perforants supplémentaires
-  Niveau 21 : Inflige 1d20 points de dégâts perforants supplémentaires
-```
+<pre><code>
+- Niveau 1 à 2 : Inflige 1 point de dégâts perforants supplémentaires
+- Niveau 3 à 5 : Inflige 1d4 points de dégâts perforants supplémentaires
+- Niveau 6 à 8 : Inflige 1d6 points de dégâts perforants supplémentaires
+- Niveau 9 à 11 : Inflige 1d8 points de dégâts perforants supplémentaires
+- Niveau 12 à 14 : Inflige 2d4 points de dégâts perforants supplémentaires
+- Niveau 15 à 17 : Inflige 1d10 points de dégâts perforants supplémentaires
+- Niveau 18 à 20 : Inflige 2d6 points de dégâts perforants supplémentaires
+- Niveau 21 : Inflige 1d20 points de dégâts perforants supplémentaires
+
+</code></pre>
 </details>
 <ul>
-<li>4ème Niveau : Peut utiliser la capacité « Entrave » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.</li>
+<li><p>4ème Niveau : Peut utiliser la capacité « Entrave » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.</p>
+</li>
 </ul>
 <p>ENTRAVE : Le Lancier Dragon est capable de parfaire certaines techniques lui permettant de ralentir ses ennemis. Pendant 10 secondes chaque adversaire touché verra sa vitesse de déplacement réduite de 2 pour deux round. Les effets sont cumulatifs à chaque coup donné. Un jet de sauvegarde contre la mort à -4 est nécessaire pour annuler les effets.</p>
 <p>Inconvénients :</p>
@@ -100,42 +99,42 @@
 <p>CHOC PSIONIQUE : Pendant un round, cette capacité permet à l'Esprit Guerrier d'effectuer une attaque spéciale et des dégâts supplémentaires contre n'importe quel type d'ennemi en appliquant un modificateur lié à l'intelligence.</p>
 <details>
   <summary>Détails des dégâts</summary>
-  
-```	
-	13 en Intelligence : Inflige 1 point de dégâts supplémentaires
-	14 en Intelligence : Inflige 2 points de dégâts supplémentaires 
-	15 en Intelligence : Inflige 3 points de dégâts supplémentaires 
-	16 en Intelligence : Inflige 4 points de dégâts supplémentaires 
-	17 en Intelligence : Inflige 4 points de dégâts supplémentaires 
-	18 en Intelligence : Inflige 5 points de dégâts supplémentaires 
-	19 en Intelligence : Inflige 8 points de dégâts supplémentaires 
-	20 en Intelligence : Inflige 9 points de dégâts supplémentaires 
-	21 en Intelligence : Inflige 10 points de dégâts supplémentaires 
-	22 en Intelligence : Inflige 11 points de dégâts supplémentaires 
-	23 en Intelligence : Inflige 12 points de dégâts supplémentaires 
-	24 en Intelligence : Inflige 13 points de dégâts supplémentaires 
-	25 en Intelligence : Inflige 14 points de dégâts supplémentaires 
-```
+<pre><code>
+- 13 en Intelligence : Inflige 1 point de dégâts supplémentaires
+- 14 en Intelligence : Inflige 2 points de dégâts supplémentaires
+- 15 en Intelligence : Inflige 3 points de dégâts supplémentaires
+- 16 en Intelligence : Inflige 4 points de dégâts supplémentaires
+- 17 en Intelligence : Inflige 4 points de dégâts supplémentaires
+- 18 en Intelligence : Inflige 5 points de dégâts supplémentaires
+- 19 en Intelligence : Inflige 8 points de dégâts supplémentaires
+- 20 en Intelligence : Inflige 9 points de dégâts supplémentaires
+- 21 en Intelligence : Inflige 10 points de dégâts supplémentaires
+- 22 en Intelligence : Inflige 11 points de dégâts supplémentaires
+- 23 en Intelligence : Inflige 12 points de dégâts supplémentaires
+- 24 en Intelligence : Inflige 13 points de dégâts supplémentaires
+- 25 en Intelligence : Inflige 14 points de dégâts supplémentaires
+	
+</code></pre>
 </details>
 <p>CHAMP DE FORCE : Pendant un round, cette capacité permet à l'Esprit Guerrier d'amortir les dégâts physiques en appliquant un modificateur lié à l'intelligence.</p>
 <details>
   <summary>Détails des résistances</summary>
-  
-```	
-	13 en Intelligence : Bonus de 2 % de résistance aux dégâts physiques 
-	14 en Intelligence : Bonus de 4 % de résistance aux dégâts physiques  
-	15 en Intelligence : Bonus de 6 % de résistance aux dégâts physiques  
-	16 en Intelligence : Bonus de 8 % de résistance aux dégâts physiques  
-	17 en Intelligence : Bonus de 8 % de résistance aux dégâts physiques  
-	18 en Intelligence : Bonus de 10 % de résistance aux dégâts physiques  
-	19 en Intelligence : Bonus de 16 % de résistance aux dégâts physiques  
-	20 en Intelligence : Bonus de 18 % de résistance aux dégâts physiques  
-	21 en Intelligence : Bonus de 20 % de résistance aux dégâts physiques  
-	22 en Intelligence : Bonus de 22 % de résistance aux dégâts physiques  
-	23 en Intelligence : Bonus de 24 % de résistance aux dégâts physiques  
-	24 en Intelligence : Bonus de 26 % de résistance aux dégâts physiques  
-	25 en Intelligence : Bonus de 28 % de résistance aux dégâts physiques  
-```
+<pre><code>
+- 13 en Intelligence : Bonus de 2 % de résistance aux dégâts physiques
+- 14 en Intelligence : Bonus de 4 % de résistance aux dégâts physiques
+- 15 en Intelligence : Bonus de 6 % de résistance aux dégâts physiques
+- 16 en Intelligence : Bonus de 8 % de résistance aux dégâts physiques
+- 17 en Intelligence : Bonus de 8 % de résistance aux dégâts physiques
+- 18 en Intelligence : Bonus de 10 % de résistance aux dégâts physiques
+- 19 en Intelligence : Bonus de 16 % de résistance aux dégâts physiques
+- 20 en Intelligence : Bonus de 18 % de résistance aux dégâts physiques
+- 21 en Intelligence : Bonus de 20 % de résistance aux dégâts physiques
+- 22 en Intelligence : Bonus de 22 % de résistance aux dégâts physiques
+- 23 en Intelligence : Bonus de 24 % de résistance aux dégâts physiques
+- 24 en Intelligence : Bonus de 26 % de résistance aux dégâts physiques
+- 25 en Intelligence : Bonus de 28 % de résistance aux dégâts physiques
+	
+</code></pre>
 </details>
 <ul>
 <li>7ème niveau : Peut utiliser « Attraction cinétique » une fois par jour, puis une fois supplémentaire tous les 5 niveaux.</li>
@@ -189,25 +188,25 @@
 <ul>
 <li><p>Peut lancer « Imposition des mains » une fois par jour pour rendre à une créature un maximum de 2 points de vie par niveau du Champion de la nature</p>
 </li>
-<li><p>2ème niveau : Gagne la capacité passive « Finesse ».</p>
+<li><p>–2ème niveau : Gagne la capacité passive « Finesse ».</p>
 </li>
 </ul>
 <p>FINESSE : Le Champion de la nature devient capable de porter des attaques qui infligent des dégâts considérables toute en finesse. Le personnage applique un modificateur lié à la Dextérité pour améliorer son jet de dégâts (en plus des potentiels bonus lié à la Force). Les bonus sont les suivants :</p>
 <details>
   <summary>Détails des dégâts</summary>
-  
-```	
-	16 en Dextérité : Bonus de 1 point de dégâts avec une arme de mêlée
-	17 en Dextérité : Bonus de 2 point de dégâts avec une arme de mêlée
-	18 en Dextérité : Bonus de 2 point de dégâts avec une arme de mêlée
-	19 en Dextérité : Bonus de 3 point de dégâts avec une arme de mêlée
-	20 en Dextérité : Bonus de 3 point de dégâts avec une arme de mêlée
-	21 en Dextérité : Bonus de 4 point de dégâts avec une arme de mêlée
-	22 en Dextérité : Bonus de 4 point de dégâts avec une arme de mêlée
-	23 en Dextérité : Bonus de 4 point de dégâts avec une arme de mêlée
-	24 en Dextérité : Bonus de 5 point de dégâts avec une arme de mêlée
-	25 en Dextérité : Bonus de 6 point de dégâts avec une arme de mêlée
-  ```
+<pre><code>
+- 16 en Dextérité : Bonus de 1 point de dégâts avec une arme de mêlée
+- 17 en Dextérité : Bonus de 2 point de dégâts avec une arme de mêlée
+- 18 en Dextérité : Bonus de 2 point de dégâts avec une arme de mêlée
+- 19 en Dextérité : Bonus de 3 point de dégâts avec une arme de mêlée
+- 20 en Dextérité : Bonus de 3 point de dégâts avec une arme de mêlée
+- 21 en Dextérité : Bonus de 4 point de dégâts avec une arme de mêlée
+- 22 en Dextérité : Bonus de 4 point de dégâts avec une arme de mêlée
+- 23 en Dextérité : Bonus de 4 point de dégâts avec une arme de mêlée
+- 24 en Dextérité : Bonus de 5 point de dégâts avec une arme de mêlée
+- 25 en Dextérité : Bonus de 6 point de dégâts avec une arme de mêlée
+	
+</code></pre>
 </details>
 <ul>
 <li>4ème niveau : Peut utiliser la capacité « Fureur sauvage » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.</li>
@@ -268,6 +267,28 @@
 <li>Ne peut pas utiliser la capacité Repousser les morts-vivants.</li>
 <li>Ne peut pas investir plus d'un point de compétence dans les armes à deux mains et les armes à distance.</li>
 </ul>
+<h3 id="ravageur">Ravageur</h3>
+<p>Les Ravageurs sont des guerriers maléfiques qui se délectent de la mort et de la destruction de toute forme de vie. Utilisant les arts nécrotiques pour le combat, ils drainent l'essence vitale de leurs adversaires, et certains d'entre eux peuvent même dévorer l'âme de leurs victimes.</p>
+<p>Avantages :</p>
+<ul>
+<li>Peut utiliser la capacité « Siphon » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.</li>
+</ul>
+<p>SIPHON : Chaque coup réussi dans les 10 secondes qui suivent draine 1d4 points de vie à la cible et les transfère au Ravageur. Cette capacité ne permet de dépasser son maximum de points de vie.</p>
+<ul>
+<li>5ème Niveau : Gagne la capacité passive « Dévoreur d'âme ».</li>
+</ul>
+<p>DÉVOREUR D'ÂME : Quand le Ravageur terrasse un adversaire, il a 20 % de chances d'aspirer son essence vitale et de récupérer 10 points de vie.</p>
+<ul>
+<li>10ème Niveau : Peut utiliser la capacité « Champ de mort » une fois par jour, puis une fois supplémentaire tous les 5 niveaux.</li>
+</ul>
+<p>CHAMP DE MORT : Tous les ennemis situés dans un rayon de 4,5 mètres autour du Ravageur subissent 4 points de dégâts. Le Ravageur absorbe cette énergie vitale même au-delà de son maximum de points de vie. Ces points de vie supplémentaires disparaîtront après 1 tour. </p>
+<p>Inconvénients :</p>
+<ul>
+<li>Alignement mauvais uniquement.</li>
+<li>Ne peut pas lancer « Détection du mal ».</li>
+<li>Ne dispose pas de la capacité innée « Protection contre le mal ».</li>
+<li>Ne peut utiliser « Imposition des mains ».</li>
+</ul>
 <h2 id="kits-de-clerc">Kits de Clerc</h2>
 <h2 id="kits-de-druide">Kits de Druide</h2>
 <h2 id="kits-de-mage">Kits de Mage</h2>
@@ -301,14 +322,12 @@
 <p>Les seigneurs de l'orage manipulent le tonnerre et la foudre comme les guerrier manient leur épée. En raison de leur maîtrise de l'un des éléments les plus destructeurs de la nature, ils sont perçus avec crainte et admiration par les gens ordinaires, quelle que soit leur motivation.</p>
 <p>Avantages :</p>
 <ul>
-<li><p>1er niveau : Bonus de 1 aux jets de toucher et de dégâts, gagne un bonus supplémentaire au 6ème niveau et un autre au 9ème niveau.</p>
-</li>
-<li><p>3ème niveau : Peut utiliser « Induction » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.</p>
-</li>
+<li>1er niveau : Bonus de 1 aux jets de toucher et de dégâts, gagne un bonus supplémentaire au 6ème niveau et un autre au 9ème niveau.</li>
+<li>3ème niveau : Peut utiliser « Induction » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.</li>
 </ul>
 <p>INDUCTION : Le Seigneur de l'Orage insuffle 1d8 points de dégâts d'électricité à son arme pendant 2 tours.</p>
 <ul>
-<li>4ème niveau : Le Seigneur de l'Orage gagne 25 % d'immunité aux dégâts électriques. Cette immunité passe à 50 % au niveau 8, 75 % au niveau 12 et 100 % au niveau 14.</li>
+<li>4ème niveau : Le Seigneur de l'Orage gagne 25 % d'immunité aux dégâts électriques. Cette immunité passe à 50 % au niveau 8, à 75 % au niveau 12 et 100 % au niveau 14.</li>
 </ul>
 <p>Inconvénients :</p>
 <ul>
@@ -331,28 +350,26 @@
 <ul>
 <li>20ème Niveau : Peut utiliser la capacité « Sauvagerie » une fois par jour, puis une fois supplémentaire tous les 5 niveaux.</li>
 </ul>
-<p>SAUVAGERIE : Au cours des 10 secondes qui suivent les attaques du Semeur de Mort affaiblissent progressivement ses adversaires en leur faisant perdre 1 point de constitution pendant 2 rounds.</p>
+<p>SAUVAGERIE : Au cours des 10 secondes qui suivent les attaques du Semeur de Mort affaiblissent progressivement ses adversaires en leur faisant perdre 1 point de Constitution pendant 2 rounds.</p>
 <p>Inconvénients :</p>
 <ul>
 <li>Alignement mauvais uniquement.</li>
 <li>Ne peut se jumeler.</li>
 </ul>
-<p>Remarque : Cette classe de prestige exige que le joueur réunisse les conditions suivantes :</p>
+<p>Veuillez noter que cette classe de prestige nécessite :</p>
 <ul>
 <li>Être le protagoniste</li>
 <li>Classe de guerrier de niveau 15</li>
-<li>Ne pas avoir de kit, ne pas être multiclassé ou jumelé</li>
-<li>Doit avoir une Force et une Constitution de 18 ou plus</li>
-<li>Doit être d'alignement maléfique</li>
+<li>Ne pas être multiclassé ou jumelé et ne pas posséder de kit</li>
+<li>Avoir 18 ou plus en Force et Constitution</li>
+<li>Être d'alignement mauvais</li>
 </ul>
 <h3 id="archimage---classe-de-mage">Archimage - Classe de Mage</h3>
 <p>Les Archimages sont des maîtres en magie très puissant et généralement d'un âge avancé, il se consacrent à l'étude des arcanes. Ceux qui sont bienveillants conseillent souvent les rois et les reines, tandis que les Archimages maléfiques règnent en tyrans et aspirent souvent à la vie éternelle par tous les moyen, même la transformation en liche. Ceux qui ne sont ni l'un ni l'autre s'enferment dans des tours reculées pour pratiquer leur magie sans être importunés.</p>
 <p>Avantages :</p>
 <ul>
-<li><p>Bonus de 1 au niveau du lanceur de sort.</p>
-</li>
-<li><p>18ème Niveau : Peut utiliser la capacité « Feu des arcanes » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.</p>
-</li>
+<li>Bonus de 1 au niveau du lanceur de sort.</li>
+<li>18ème Niveau : Peut utiliser la capacité « Feu des arcanes » une fois par jour, puis une fois supplémentaire tous les 4 niveaux.</li>
 </ul>
 <p>FEU DES ARCANES : L'Archimage apprend à canaliser l'énergie des arcanes pour s'en servir comme une arme, ce qui lui permet d'être capable de se défendre même lorsque ses sorts sont épuisés. Cette capacité lui permet de libérer une impulsion d'énergie magique qui inflige à une créature 1d6 points de dégâts par niveau d'Archimage. La résistance à la magie de la cible est ignorée par cette capacité.</p>
 <ul>
@@ -360,21 +377,19 @@
 </ul>
 <p>TISSEUR DE SORT : L'Archimage a acquis une compréhension approfondie de la magie et de ses mécanismes. Une fois par jour, il peut utiliser Souhait mineur comme capacité spéciale.</p>
 <ul>
-<li><p>23ème Niveau : L'Archimage améliore la capacité « Feu des arcanes ». Maintenant la créature touchée est également affectée par une Dissipation de la magie.</p>
-</li>
-<li><p>25ème Niveau : Peut utiliser la capacité « Haut-Mage » une fois par jour.</p>
-</li>
+<li>23ème Niveau : L'Archimage améliore la capacité « Feu des arcanes ». Maintenant la créature touchée est également affectée par une Dissipation de la magie.</li>
+<li>25ème Niveau : Peut utiliser la capacité « Haut-Mage » une fois par jour.</li>
 </ul>
 <p>HAUT-MAGE: L'incantation de cette capacité dure un round complet et permet à l'Archimage de remettre en mémoire tous ses sortilèges.</p>
 <p>Inconvénients :</p>
 <ul>
 <li>Ne peut se jumeler.</li>
 </ul>
-<p>Remarque : Cette classe de prestige exige que le joueur réunisse les conditions suivantes :</p>
+<p>Veuillez noter que cette classe de prestige nécessite :</p>
 <ul>
 <li>Être le protagoniste</li>
 <li>Classe de mage non spécialiste de niveau 18</li>
-<li>Ne pas avoir de kit, ne pas être multiclassé ou jumelé</li>
+<li>Ne pas être multiclassé ou jumelé et ne pas posséder de kit</li>
 <li>Avoir une Intelligence de 19 ou plus</li>
 <li>Avoir une Sagesse de 15 ou plus</li>
 </ul>


### PR DESCRIPTION
@morpheus562 

_A suggestion for the Reaver, its three abilities absorb health points, which is a bit repetitive..._

_So for DEVOUR SOUL, I suggest_ : When the Reaver kills an opponent, there is a 20% chance <PRO_HESHE> consumes the remaining life essence and **receive one point of constitution or strength for one day.**

_And for DEATH FIELD_ : All enemies within a 15-ft. radius of the Reaver suffers 4 damage each while the Reaver absorbs the enemy's lost life. If the Reaver goes over <PRO_HISHER> maximum Hit Point total with this ability, <PRO_HESHE> loses any extra Hit Points after 1 turn. **In addition, there is a 4% chance that some of them see their lives completely consumed and die instantly  (creatures with more than 9 Hit Dice are immune to the death effect).**

_Just a thought, other variations might be better._